### PR TITLE
New feature: Recursive entrypoint

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -26,5 +26,6 @@ catkin build
 # https://github.com/osrf/docker_images/issues/114
 printf "\nsource '$PWD/devel/setup.bash'" >> $HOME/.bashrc
 
-exec "$@"
+# recursively execute entrypoints
+exec $(find_entrypoints) "$@"
 

--- a/util/config.sh
+++ b/util/config.sh
@@ -68,6 +68,26 @@ istrue() {
     return $?
 }
 
+# Find all directories that (immediately) contains a file named TARGET.
+# Once a file is found do not continue searching in subdirectories.
+# > shallow_find TARGET [PATHS...]
+shallow_find() {
+    TARGET="$1"
+    shift
+    find "$@"                                               \
+        -mindepth 1                                         \
+        -type d                                             \
+        -exec sh -c 'test -f "$1/$2"' -- {} "$TARGET" \;    \
+        -prune                                              \
+        -print
+    return $?
+}
+
+find_entrypoints() {
+    shallow_find 'entrypoint' "$REPOSITORY_PATH" | tr '\n' ' '
+    return $?
+}
+
 
 ################################################################################
 ################################################################################


### PR DESCRIPTION
This feature would allow a way for packages to insert code during container build.

1. Build image (docker build), sets up top-level entrypoint
   - rosdep install in Dockerfile
   - pip install requirements in Dockerfile
   - catkin build in Dockerfile
2. Run container (docker run), calls entrypoint
   - rosdep install in entrypoint
   - catkin build in entrypoint
   - execute next entrypoint in subdirectory (this can do whatever)

An entrypoint in a package can for example call their own pip install requirements or apt install to ensure non-rosdep packages are installed.

OBS: This PR is a placeholder in wait for upcoming PRs. 