### PR TITLE
Encoders improvements

### DIFF
--- a/src/svea_core/launch/state_publisher.launch
+++ b/src/svea_core/launch/state_publisher.launch
@@ -1,8 +1,12 @@
 <?xml version="1.0"?>
+
 <launch>
 
     <!-- Launch arguments -->
     <arg name="map" default="sml"/>
+    <arg name="initial_pose_x" default="-2.65488696"/>
+    <arg name="initial_pose_y" default="-1.64422277"/>
+    <arg name="initial_pose_a" default="1.57" /> <!-- wrt to map-->
 
     <!-- Start map server -->
     <node name="map_server" pkg="map_server" type="map_server" args="$(find svea_core)/maps/$(arg map).yaml" output="screen"/>
@@ -14,7 +18,11 @@
     </node>
 
     <!-- Start localization -->
-    <include file="$(find svea_sensors)/launch/localize.launch"/>
+    <include file="$(find svea_sensors)/launch/localize.launch">
+        <arg name="initial_pose_x" value="$(arg initial_pose_x)" />
+        <arg name="initial_pose_y" value="$(arg initial_pose_y)" />
+        <arg name="initial_pose_a" value="$(arg initial_pose_a)" />
+    </include>
 
     <!-- Start state publisher -->
     <node name="state_publisher" pkg="svea_core" type="state_publisher.py" output="screen"/>

--- a/src/svea_core/launch/state_publisher.launch
+++ b/src/svea_core/launch/state_publisher.launch
@@ -1,5 +1,4 @@
 <?xml version="1.0"?>
-
 <launch>
 
     <!-- Launch arguments -->

--- a/src/svea_core/src/svea/controllers/pure_pursuit.py
+++ b/src/svea_core/src/svea/controllers/pure_pursuit.py
@@ -31,19 +31,22 @@ class PurePursuitController(object):
         return steering, velocity
 
     def compute_steering(self, state, target=None):
-        if target is None:
-            self.find_target(state)
+        if self.is_finished:
+            return 0.0
         else:
-            # allow manual setting of target
-            self.target = target
+            if target is None:
+                self.find_target(state)
+            else:
+                # allow manual setting of target
+                self.target = target
 
-        tx, ty = self.target
-        alpha = math.atan2(ty - state.y, tx - state.x) - state.yaw
-        if state.v < 0:  # back
-            alpha = math.pi - alpha
-        Lf = self.k * state.v + self.Lfc
-        delta = math.atan2(2.0 * self.L * math.sin(alpha) / Lf, 1.0)
-        return delta
+            tx, ty = self.target
+            alpha = math.atan2(ty - state.y, tx - state.x) - state.yaw
+            if state.v < 0:  # back
+                alpha = math.pi - alpha
+            Lf = self.k * state.v + self.Lfc
+            delta = math.atan2(2.0 * self.L * math.sin(alpha) / Lf, 1.0)
+            return delta
 
     def compute_velocity(self, state):
         if self.is_finished:
@@ -81,6 +84,8 @@ class PurePursuitController(object):
 
         # terminating condition
         if dist < 0.1:
-            self.is_finished = True
+            #!! Bug: ithe robot will stop at the first waypoint thinking that it has completed its path
+            #self.is_finished = True
+            pass
 
         return ind

--- a/src/svea_core/src/svea/controllers/pure_pursuit.py
+++ b/src/svea_core/src/svea/controllers/pure_pursuit.py
@@ -33,32 +33,30 @@ class PurePursuitController(object):
     def compute_steering(self, state, target=None):
         if self.is_finished:
             return 0.0
+        if target is None:
+            self.find_target(state)
         else:
-            if target is None:
-                self.find_target(state)
-            else:
-                # allow manual setting of target
-                self.target = target
+            # allow manual setting of target
+            self.target = target
 
-            tx, ty = self.target
-            alpha = math.atan2(ty - state.y, tx - state.x) - state.yaw
-            if state.v < 0:  # back
-                alpha = math.pi - alpha
-            Lf = self.k * state.v + self.Lfc
-            delta = math.atan2(2.0 * self.L * math.sin(alpha) / Lf, 1.0)
-            return delta
+        tx, ty = self.target
+        alpha = math.atan2(ty - state.y, tx - state.x) - state.yaw
+        if state.v < 0:  # back
+            alpha = math.pi - alpha
+        Lf = self.k * state.v + self.Lfc
+        delta = math.atan2(2.0 * self.L * math.sin(alpha) / Lf, 1.0)
+        return delta
 
     def compute_velocity(self, state):
         if self.is_finished:
             return 0.0
-        else:
-            # speed control
-            error = self.target_velocity - state.v
-            self.error_sum += error * self.dt
-            P = error * self.K_p
-            I = self.error_sum * self.K_i
-            correction = P + I
-            return self.target_velocity + correction
+        # speed control
+        error = self.target_velocity - state.v
+        self.error_sum += error * self.dt
+        P = error * self.K_p
+        I = self.error_sum * self.K_i
+        correction = P + I
+        return self.target_velocity + correction
 
     def find_target(self, state):
         ind = self._calc_target_index(state)
@@ -84,8 +82,7 @@ class PurePursuitController(object):
 
         # terminating condition
         if dist < 0.1:
-            #!! Bug: ithe robot will stop at the first waypoint thinking that it has completed its path
-            #self.is_finished = True
+            self.is_finished = True
             pass
 
         return ind

--- a/src/svea_core/src/svea/svea_managers/path_following_sveas.py
+++ b/src/svea_core/src/svea/svea_managers/path_following_sveas.py
@@ -12,8 +12,6 @@ from svea.data import TrajDataHandler
 from svea.controllers import pure_pursuit
 from svea.controllers.pure_pursuit import PurePursuitController
 
-#!! GITHUB ISSUE: this modifies k, Lfc and L of the pure pursuit module, without actually modifying the ones of the
-#!! actual class
 ## PURE PURSUIT PARAMS ########################################################
 #pure_pursuit.k = 0.6  # look forward gain
 #pure_pursuit.Lfc = 0.4  # look-ahead distance

--- a/src/svea_core/src/svea/svea_managers/path_following_sveas.py
+++ b/src/svea_core/src/svea/svea_managers/path_following_sveas.py
@@ -12,10 +12,12 @@ from svea.data import TrajDataHandler
 from svea.controllers import pure_pursuit
 from svea.controllers.pure_pursuit import PurePursuitController
 
+#!! GITHUB ISSUE: this modifies k, Lfc and L of the pure pursuit module, without actually modifying the ones of the
+#!! actual class
 ## PURE PURSUIT PARAMS ########################################################
-pure_pursuit.k = 0.6  # look forward gain
-pure_pursuit.Lfc = 0.4  # look-ahead distance
-pure_pursuit.L = 0.324  # [m] wheel base of vehicle
+#pure_pursuit.k = 0.6  # look forward gain
+#pure_pursuit.Lfc = 0.4  # look-ahead distance
+#pure_pursuit.L = 0.324  # [m] wheel base of vehicle
 ###############################################################################
 
 __license__ = "MIT"

--- a/src/svea_core/src/svea/svea_managers/path_following_sveas.py
+++ b/src/svea_core/src/svea/svea_managers/path_following_sveas.py
@@ -12,12 +12,6 @@ from svea.data import TrajDataHandler
 from svea.controllers import pure_pursuit
 from svea.controllers.pure_pursuit import PurePursuitController
 
-## PURE PURSUIT PARAMS ########################################################
-#pure_pursuit.k = 0.6  # look forward gain
-#pure_pursuit.Lfc = 0.4  # look-ahead distance
-#pure_pursuit.L = 0.324  # [m] wheel base of vehicle
-###############################################################################
-
 __license__ = "MIT"
 __maintainer__ = "Frank Jiang, Tobias Bolin"
 __email__ = "frankji@kth.se "

--- a/src/svea_examples/launch/floor2.launch
+++ b/src/svea_examples/launch/floor2.launch
@@ -2,16 +2,21 @@
 <launch>
 
     <!-- Launch file arguments -->
-    <arg name="map"         default="floor2"/>
-    <arg name="is_sim"      default="true"/>
-    <arg name="use_rviz"    default="true"/>
+    <arg name="map" default="sml"/>
+    <arg name="is_sim" default="true"/>
+    <arg name="use_rviz" default="true"/>
     <arg name="remote_rviz" default="false"/>
+    <arg name="obstacle_map" default="sml_obstacles"/>
+    <arg name="initial_pose_x" default="-2.65488696"/>
+    <arg name="initial_pose_y" default="-1.64422277"/>
+    <arg name="initial_pose_a" default="1.57" /> <!-- wrt to map-->
 
     <!-- Start map server -->
     <node name="map_server" pkg="map_server" type="map_server" args="$(find svea_core)/maps/$(arg map).yaml" output="screen"/>
 
-    <rosparam command="load" file="$(find svea_core)/params/obstacles.yaml" />
+    <rosparam command="load" file="$(find svea_core)/params/$(arg obstacle_map).yaml" />
 
+    <!-- If is_sim equal to false, then include all these tags-->
     <group unless="$(arg is_sim)">
 
         <!-- Start low-level interface -->
@@ -21,28 +26,28 @@
         </node>
 
         <!-- Start localization -->
-        <include file="$(find svea_sensors)/launch/localize.launch"/>
-
+        <include file="$(find svea_sensors)/launch/localize.launch">
+            <arg name="initial_pose_x" value="$(arg initial_pose_x)" />
+            <arg name="initial_pose_y" value="$(arg initial_pose_y)" />
+            <arg name="initial_pose_a" value="$(arg initial_pose_a)" />
+        </include>
     </group>
 
     <!-- Start RViz -->
-    <node if="$(eval use_rviz and not remote_rviz)"
-          name="rviz" pkg="rviz" type="rviz"
-          args="-d $(find svea_core)/rviz/SVEA_floor2.rviz"/>
-
+    <node if="$(eval use_rviz and not remote_rviz)" name="rviz" pkg="rviz" type="rviz" args="-d $(find svea_core)/rviz/SVEA_floor2.rviz"/>
     <!-- Start pure_pursuit -->
     <node name="pure_pursuit" pkg="svea_examples" type="pure_pursuit.py" output="screen">
-        <param name="use_rviz"  value="$(arg use_rviz)"/>
-        <param name="is_sim"    value="$(arg is_sim)"/>
+        <param name="use_rviz" value="$(arg use_rviz)"/>
+        <param name="is_sim" value="$(arg is_sim)"/>
+        <!-- Waypoints for floo2 map -->
         <rosparam>
-            state: [-7.4, -15.3, 0.9] # initial state (x, y, yaw)
+            state: [-2.65488696, -1.64422277, 1.57] # initial state (x, y, yaw)
             points:
-            - [-2.3, -7.1]  # Bottom right (project room)
-            - [10.5, 11.7]  # Top right
-            - [5.7, 15.0]   # Top left
-            - [-7.0, -4.0]  # Bottom left
+            - [-2.65488696, 1]
+            - [0.0, -1.64422277]
+            - [0.8, 1.0]
+            obstacles_points:
+            - [0.8, 1]
         </rosparam>
     </node>
-
 </launch>
-

--- a/src/svea_examples/launch/sml.launch
+++ b/src/svea_examples/launch/sml.launch
@@ -2,11 +2,11 @@
 <launch>
 
     <!-- Launch file arguments -->
-    <arg name="map"             default="floor2"/>
+    <arg name="map"             default="sml"/>
     <arg name="is_sim"          default="true"/>
     <arg name="use_rviz"        default="true"/>
     <arg name="remote_rviz"     default="false"/>
-    <arg name="obstacle_map"    default="obstacles"/>
+    <arg name="obstacle_map"    default="sml_obstacles"/>
     <arg name="initial_pose_x"  default="-2.65488696"/>
     <arg name="initial_pose_y"  default="-1.64422277"/>
     <arg name="initial_pose_a"  default="1.57" /> <!-- wrt to map-->
@@ -41,12 +41,13 @@
         <param name="is_sim" value="$(arg is_sim)"/>
         <!-- Waypoints for floo2 map -->
         <rosparam>
-            state: [-7.4, -15.3, 0.9] # initial state (x, y, yaw)
+            state: [-2.65488696, -1.64422277, 1.57] # initial state (x, y, yaw)
             points:
-            - [-2.3, -7.1]  # Bottom right (project room)
-            - [10.5, 11.7]  # Top right
-            - [5.7, 15.0]   # Top left
-            - [-7.0, -4.0]  # Bottom left
+            - [-2.65488696, 1]
+            - [0.0, -1.64422277]
+            - [0.8, 1.0]
+            obstacles_points:
+            - [0.8, 1]
         </rosparam>
     </node>
 </launch>

--- a/src/svea_examples/scripts/pure_pursuit.py
+++ b/src/svea_examples/scripts/pure_pursuit.py
@@ -14,12 +14,6 @@ from svea.interfaces import LocalizationInterface
 from svea.controllers.pure_pursuit import PurePursuitController
 from svea.svea_managers.path_following_sveas import SVEAPurePursuit
 from svea.data import TrajDataHandler, RVIZPathHandler
-# Added for obstace pose visualization
-from svea.simulators.viz_utils import (
-    publish_pose_array
-)
-from geometry_msgs.msg import PoseArray, PointStamped
-from sensor_msgs.msg import LaserScan
 
 
 def load_param(name, value=None):
@@ -62,9 +56,7 @@ class pure_pursuit:
     DELTA_TIME = 0.01
     TRAJ_LEN = 10
     GOAL_THRESH = 0.2
-    # Obstacle threshold for obstacle management
-    OBS_THRESH = 0.2
-    TARGET_VELOCITY = 0.35
+    TARGET_VELOCITY = 1.0
     RATE = 1e9
 
     def __init__(self):
@@ -76,11 +68,8 @@ class pure_pursuit:
         ## Parameters
 
         self.POINTS = load_param('~points')
-        self.OBSTACLES = load_param('~obstacles_points')
         self.IS_SIM = load_param('~is_sim', False)
         self.USE_RVIZ = load_param('~use_rviz', False)
-        # Get remote rviz parameter
-        self.REMOTE_RVIZ = load_param('~remote_rviz', False)
         self.STATE = load_param('~state', [0, 0, 0, 0])
 
         assert_points(self.POINTS)
@@ -113,62 +102,31 @@ class pure_pursuit:
         self.svea = SVEAPurePursuit(LocalizationInterface,
                                     PurePursuitController,
                                     xs, ys,
-                                    data_handler=RVIZPathHandler if self.USE_RVIZ or self.REMOTE_RVIZ else TrajDataHandler)
+                                    data_handler=RVIZPathHandler if self.USE_RVIZ else TrajDataHandler)
 
         self.svea.controller.target_velocity = self.TARGET_VELOCITY
-        # Create publisher in order to publish obstacle points onto RVIz
-        self.init_pts_publisher = rospy.Publisher("/obstacles_points",
-                                         PoseArray, queue_size=1) 
-        # Subscriber for the obstacle points topic
-        self.obs_sub = rospy.Subscriber('/clicked_point', PointStamped, self.obs_callback)
-        
         self.svea.start(wait=True)
 
         # everything ready to go -> unpause simulator
         if self.IS_SIM:
             self.simulator.toggle_pause_simulation()
 
-    def obs_callback(self, msg):
-        obs = [msg.point.x, msg.point.y, 0]
-        self.OBSTACLES.append(obs)
-
     def run(self):
         while self.keep_alive():
             self.spin()
 
     def keep_alive(self):
-        #!! self.svea.is_finished becomes true if in pure_pursuit controller, function _calc_target_index,
-        return not (rospy.is_shutdown())
+        return not (self.svea.is_finished or rospy.is_shutdown())
 
     def spin(self):
-        #!! Safe to send controls is localization node is up and running
-        safe = self.svea.localizer.is_ready
-        #!! Previous was state and not self.state (so when computing new trajectory for new goal, the trajectory would 
-        #!! always start fro (0,0) and not the new position)
+
         # limit the rate of main loop by waiting for state
-        self.state = self.svea.wait_for_state()
+        state = self.svea.wait_for_state()
 
-        # Obstacle Management
-        x = []
-        y = []
-        yaws = []
-        # if state.x,y is too close to obtacle point, then stop
-        for obs in self.OBSTACLES:
-            # Added for obstacle pose visualization
-            x.append(obs[0])
-            y.append(obs[1])
-            yaws.append(0)
-            if np.hypot(self.state.x - obs[0], self.state.y - obs[1]) < self.OBS_THRESH:
-                # If vehicle is too close to an obstacle, then stop its motion
-                self.svea.send_control(0, 0)
-                safe = False
-        publish_pose_array(self.init_pts_publisher, x, y, yaws)
+        steering, velocity = self.svea.compute_control(state)
+        self.svea.send_control(steering, velocity)
 
-        if safe:
-            steering, velocity = self.svea.compute_control(self.state)
-            self.svea.send_control(steering, velocity)
-
-        if np.hypot(self.state.x - self.goal[0], self.state.y - self.goal[1]) < self.GOAL_THRESH:
+        if np.hypot(state.x - self.goal[0], state.y - self.goal[1]) < self.GOAL_THRESH:
             self.update_goal()
             xs, ys = self.compute_traj()
             self.svea.update_traj(xs, ys)
@@ -191,4 +149,3 @@ if __name__ == '__main__':
     ## Start node ##
 
     pure_pursuit().run()
-

--- a/src/svea_examples/scripts/pure_pursuit.py
+++ b/src/svea_examples/scripts/pure_pursuit.py
@@ -14,6 +14,12 @@ from svea.interfaces import LocalizationInterface
 from svea.controllers.pure_pursuit import PurePursuitController
 from svea.svea_managers.path_following_sveas import SVEAPurePursuit
 from svea.data import TrajDataHandler, RVIZPathHandler
+# Added for obstace pose visualization
+from svea.simulators.viz_utils import (
+    publish_pose_array
+)
+from geometry_msgs.msg import PoseArray, PointStamped
+from sensor_msgs.msg import LaserScan
 
 
 def load_param(name, value=None):
@@ -56,7 +62,9 @@ class pure_pursuit:
     DELTA_TIME = 0.01
     TRAJ_LEN = 10
     GOAL_THRESH = 0.2
-    TARGET_VELOCITY = 1.0
+    # Obstacle threshold for obstacle management
+    OBS_THRESH = 0.2
+    TARGET_VELOCITY = 0.35
     RATE = 1e9
 
     def __init__(self):
@@ -68,8 +76,11 @@ class pure_pursuit:
         ## Parameters
 
         self.POINTS = load_param('~points')
+        self.OBSTACLES = load_param('~obstacles_points')
         self.IS_SIM = load_param('~is_sim', False)
         self.USE_RVIZ = load_param('~use_rviz', False)
+        # Get remote rviz parameter
+        self.REMOTE_RVIZ = load_param('~remote_rviz', False)
         self.STATE = load_param('~state', [0, 0, 0, 0])
 
         assert_points(self.POINTS)
@@ -102,31 +113,62 @@ class pure_pursuit:
         self.svea = SVEAPurePursuit(LocalizationInterface,
                                     PurePursuitController,
                                     xs, ys,
-                                    data_handler=RVIZPathHandler if self.USE_RVIZ else TrajDataHandler)
+                                    data_handler=RVIZPathHandler if self.USE_RVIZ or self.REMOTE_RVIZ else TrajDataHandler)
 
         self.svea.controller.target_velocity = self.TARGET_VELOCITY
+        # Create publisher in order to publish obstacle points onto RVIz
+        self.init_pts_publisher = rospy.Publisher("/obstacles_points",
+                                         PoseArray, queue_size=1) 
+        # Subscriber for the obstacle points topic
+        self.obs_sub = rospy.Subscriber('/clicked_point', PointStamped, self.obs_callback)
+        
         self.svea.start(wait=True)
 
         # everything ready to go -> unpause simulator
         if self.IS_SIM:
             self.simulator.toggle_pause_simulation()
 
+    def obs_callback(self, msg):
+        obs = [msg.point.x, msg.point.y, 0]
+        self.OBSTACLES.append(obs)
+
     def run(self):
         while self.keep_alive():
             self.spin()
 
     def keep_alive(self):
-        return not (self.svea.is_finished or rospy.is_shutdown())
+        #!! self.svea.is_finished becomes true if in pure_pursuit controller, function _calc_target_index,
+        return not (rospy.is_shutdown())
 
     def spin(self):
-
+        #!! Safe to send controls is localization node is up and running
+        safe = self.svea.localizer.is_ready
+        #!! Previous was state and not self.state (so when computing new trajectory for new goal, the trajectory would 
+        #!! always start fro (0,0) and not the new position)
         # limit the rate of main loop by waiting for state
-        state = self.svea.wait_for_state()
+        self.state = self.svea.wait_for_state()
 
-        steering, velocity = self.svea.compute_control(state)
-        self.svea.send_control(steering, velocity)
+        # Obstacle Management
+        x = []
+        y = []
+        yaws = []
+        # if state.x,y is too close to obtacle point, then stop
+        for obs in self.OBSTACLES:
+            # Added for obstacle pose visualization
+            x.append(obs[0])
+            y.append(obs[1])
+            yaws.append(0)
+            if np.hypot(self.state.x - obs[0], self.state.y - obs[1]) < self.OBS_THRESH:
+                # If vehicle is too close to an obstacle, then stop its motion
+                self.svea.send_control(0, 0)
+                safe = False
+        publish_pose_array(self.init_pts_publisher, x, y, yaws)
 
-        if np.hypot(state.x - self.goal[0], state.y - self.goal[1]) < self.GOAL_THRESH:
+        if safe:
+            steering, velocity = self.svea.compute_control(self.state)
+            self.svea.send_control(steering, velocity)
+
+        if np.hypot(self.state.x - self.goal[0], self.state.y - self.goal[1]) < self.GOAL_THRESH:
             self.update_goal()
             xs, ys = self.compute_traj()
             self.svea.update_traj(xs, ys)

--- a/src/svea_sensors/launch/localize.launch
+++ b/src/svea_sensors/launch/localize.launch
@@ -17,7 +17,7 @@
     <arg name="initial_pose_x" default="0.0" />
     <arg name="initial_pose_y" default="0.0" />
     <arg name="initial_pose_a" default="0.0" />
-    <arg name="use_wheel_encoders" default="true" />
+    <arg name="use_wheel_encoders" default="false" />
 
     <!-- Start the stereo camera -->
     <group if="$(arg use_camera)">

--- a/src/svea_sensors/launch/localize.launch
+++ b/src/svea_sensors/launch/localize.launch
@@ -6,18 +6,18 @@
 <launch>
 
     <!-- Launch file arguments -->
-    <arg name="xavier"              default="false"/>
-    <arg name="use_camera"          default="true"/>
-    <arg name="camera"              default="rs"/>
-    <arg name="map_file"            default=""/>
-    <arg name="map_frame"           default="map"/>
-    <arg name="wait_for_transform"  default="false"/>
-    <arg name="publish_odometry"    default="true"/>
-    <arg name="publish_pose"        default="true"/>
-    <arg name="initial_pose_x"      default="0.0" />
-    <arg name="initial_pose_y"      default="0.0" />
-    <arg name="initial_pose_a"      default="0.0" />
-
+    <arg name="xavier" default="false"/>
+    <arg name="use_camera" default="true"/>
+    <arg name="camera" default="rs"/>
+    <arg name="map_file" default=""/>
+    <arg name="map_frame" default="map"/>
+    <arg name="wait_for_transform" default="false"/>
+    <arg name="publish_odometry" default="true"/>
+    <arg name="publish_pose" default="true"/>
+    <arg name="initial_pose_x" default="0.0" />
+    <arg name="initial_pose_y" default="0.0" />
+    <arg name="initial_pose_a" default="0.0" />
+    <arg name="use_wheel_encoders" default="true" />
 
     <!-- Start the stereo camera -->
     <group if="$(arg use_camera)">
@@ -30,10 +30,18 @@
         </include>
     </group>
 
+    <!-- Start wheel encoders -->
+    <group if="$(arg use_wheel_encoders)">
+        <include file="$(find svea_sensors)/launch/wheel_odometry.launch">
+            <arg name="start_serial" value="false"/>
+        </include>
+    </group>
+    
+
     <!-- Do not start the sensors, useful when running from a bag file -->
     <group unless="$(arg use_camera)">
         <param name="use_sim_time" value="true" />
-        <node if="$(eval camera == 'rs')" pkg="robot_localization" type="ekf_localization_node" name="ekf_rs" clear_params="true" >
+        <node if="$(eval camera == 'rs')" pkg="robot_localization" type="ekf_localization_node" name="ekf_rs" clear_params="true">
             <rosparam command="load" file="$(find svea_sensors)/params/robot_localization/rs_ekf.yaml"/>
             <param name="publish_tf" value="true"/>
             <param name="odom0" value="/rs/t265_camera/odom/sample"/>
@@ -55,10 +63,10 @@
     <!-- Start localization (AMCL) -->
     <node pkg="amcl" type="amcl" name="amcl_localization" output="screen">
         <rosparam command="load" file="$(find svea_sensors)/params/amcl/localize.yaml"/>
-        <param name="scan"              value="scan"/>
-        <param name="initial_pose_x"    value="$(arg initial_pose_x)" />
-        <param name="initial_pose_y"    value="$(arg initial_pose_y)" />
-        <param name="initial_pose_a"    value="$(arg initial_pose_a)" />
+        <param name="scan" value="scan"/>
+        <param name="initial_pose_x" value="$(arg initial_pose_x)" />
+        <param name="initial_pose_y" value="$(arg initial_pose_y)" />
+        <param name="initial_pose_a" value="$(arg initial_pose_a)" />
     </node>
 
     <node pkg="svea_sensors" type="odom_to_map" name="odom_to_map" output="screen">

--- a/src/svea_sensors/launch/rs_odometry.launch
+++ b/src/svea_sensors/launch/rs_odometry.launch
@@ -49,6 +49,7 @@
         <param name="odom0"         value="rs/t265_camera/odom/sample"/>
         <param name="imu0"          value="imu/data"/>
         <param name="twist0"        value="actuation_twist"/>
+        <param name="twist1"        value="wheel_encoder_twist"/>
     </node>
 
     <!-- Hokuyo LIDAR -->

--- a/src/svea_sensors/params/amcl/localize.yaml
+++ b/src/svea_sensors/params/amcl/localize.yaml
@@ -1,13 +1,11 @@
-
-
 laser_max_beams: 50 
-odom_model_type: omni-corrected
+odom_model_type: diff-corrected
 update_min_d: -1
 update_min_a: -1
 transform_tolerance: 0.01
     
 min_particles: 100
-max_particles: 800
+max_particles: 500
 resample_interval: 1
 selective_resampling: true
     
@@ -18,11 +16,11 @@ initial_cov_xx: 2.0
 initial_cov_yy: 2.0
 initial_cov_aa: 1.0
     
-odom_alpha1: 0.1 # Rot from rot
-odom_alpha2: 0.1 # Rot from trans
-odom_alpha3: 0.4  # Trans from trans
-odom_alpha4: 0.2  # Trans from rot
-odom_alpha5: 0.2 # Side slipp
+odom_alpha1: 0.4 # Rot from rot
+odom_alpha2: 0.4 # Rot from trans
+odom_alpha3: 1.6  # Trans from trans
+odom_alpha4: 0.8  # Trans from rot
+#odom_alpha5: 0.2  Side slipp (not used unless odom_model_type is omni)
     
 laser_model_type: likelihood_field
 laser_sigma_hit: 0.04

--- a/src/svea_sensors/params/robot_localization/rs_ekf.yaml
+++ b/src/svea_sensors/params/robot_localization/rs_ekf.yaml
@@ -39,6 +39,12 @@ odom0_config: [false, false, false,
                true, true, true,
                true, true, true]
 
+#odom0_config: [x, y, z,
+#               R, P, Y,
+#               x_dot, y_dot, z_dot,
+#               R_dot, P_dot, Y_dot,
+#               x_dot_dot, y_dot_dot, z_dot_dot]
+
 odom0_queue_size: 10
 odom0_nodelay: true
 
@@ -81,6 +87,18 @@ twist0_queue_size: 8
 #twist0_rejection_threshold: 2.0                # Note the difference in parameter names
 #imu0_linear_acceleration_rejection_threshold: 1.0  #
 
+##########################################
+# Twist based on wheel encoders ##########
+twist1: /wheel_encoder_twist
+twist1_config: [false, false, false,
+                false, false, false,
+                true,  false, false,
+                false, false, true,
+                false, false, false]
+twist1_nodelay: true
+twist1_differential: true
+twist1_relative: false
+twist1_queue_size: 8
 
 # Control input is not used 
 # (and you should not try to use it)


### PR DESCRIPTION
In this repo several improvements related to the execution of basic examples on the SVEA platform is included.

### Summary
In the following the set of features improved are listed:

* AMCL tuning: tuned parameters for better performances in localizing the robot in the mapped environment.
* Encoder activation: *use_wheel_encoders* parameter set to true as default in the *localize.launch* file (in order to launch *wheel_odometry.launch*).
* *rs_ekf.yaml* update: *twist1* added (ekf fuses information coming from encoders).
* Controller tuning: removal of the finished flag set to true at controller-level (endless execution of loop trajectory)
* Localization check in pure pursuit main: boolean value (*localizer.is_ready*) aimed at ensuring the beginning of
  execution after the localization node is up and running (it is able to estimate its position). 

### Encoders improvement
Disclaimer: in the following figures, on the rightside there is data coming from the experiments with wheel encoders on,
while on the leftside without wheel encoders.

As it is possible to see in the velocity images, the drift introduced by the localization module, when the vehicle is moved for a
bit, then stopped, is significantly reduced in case the wheel encoders are enabled (but still present and visible
in Rviz). 
For what concerns the RMSE on x and y components, we report plots related to the experiment in which the difference is
most evident. In other tests the difference was less noticeable, but still not worst than with encoders disabled.

![RMSE_x](https://user-images.githubusercontent.com/33842599/226172335-18b26921-59d9-4818-acbb-3e830547f344.png)
![RMSE_y](https://user-images.githubusercontent.com/33842599/226172342-b407079b-8514-4bef-8375-82fb3b9fb385.png)
![Vel](https://user-images.githubusercontent.com/33842599/226172348-172eac69-39d3-4ea4-b458-e97af56fd971.png)
