### PR TITLE
patched dynamic rosserial

### DIFF
--- a/src/svea_examples/launch/auto_serial_connect.launch
+++ b/src/svea_examples/launch/auto_serial_connect.launch
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<launch>
+    <!-- Launch file arguments -->
+
+    <arg name="baud_rate" default="250000"/>
+
+    <!-- Launch the dynamic serial manager node -->
+    <node name="rosserial_dynamic" pkg="svea_examples" type="rosserial_dynamic.py" output="screen">
+        <!-- Set parameters for the node -->
+        <param name="baud" value="$(arg baud_rate)"/>
+        <param name="scan_rate" value="1"/>
+    </node>
+    
+    <!-- Debugging options -->
+    <arg name="enable_debug" default="false"/>
+    <group if="$(arg enable_debug)">
+        <node name="rqt_console" pkg="rqt_console" type="rqt_console" output="screen"/>
+        <node name="rqt_logger_level" pkg="rqt_logger_level" type="rqt_logger_level" output="screen"/>
+    </group>
+</launch>

--- a/src/svea_examples/scripts/rosserial_dynamic.py
+++ b/src/svea_examples/scripts/rosserial_dynamic.py
@@ -19,8 +19,10 @@ class DynamicSerialManager:
 
         # Parameters
         self.baud_rate = load_param("~baud", 115200)
-        self.rate = rospy.Rate(load_param("~scan_rate", 0.1))  # Scanning interval in seconds
-        
+        self.rate = rospy.Rate(
+            load_param("~scan_rate", 0.1)
+        )  # Scanning interval in seconds
+
         # Active serial clients
         self.active_clients = {}
 
@@ -36,13 +38,16 @@ class DynamicSerialManager:
             self.monitor_devices()
             self.rate.sleep()
 
-
     def monitor_devices(self):
         """
         Detect connected devices and start or stop clients accordingly.
         """
         # Detect all /dev/ttyACM* devices
-        detected_ports = {f"/dev/{dev}" for dev in os.listdir("/dev") if dev.startswith("ttyACM")}
+        detected_ports = {
+            f"/dev/{dev}"
+            for dev in os.listdir("/dev")
+            if dev.startswith("ttyACM") or dev.startswith("ttyUSB")
+        }
 
         # Start clients for new devices
         for port in detected_ports - self.active_clients.keys():


### PR DESCRIPTION
changed launch name and added ttyUSB as a valid prefix for device name. Some serial drivers end up as ttyUSB instead of just ttyACM